### PR TITLE
Fix link to Stefan's talk in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This repo contains slides, content or references as published by the speaker aft
 - [Serverless @ Studyportals: A Bird’s-eye View - Daniel Papukchiev](https://goo.gl/4fyTVt)
 - [Docker tips for Cloud Native Java Developers - Aparna Chaudhary](https://www.slideshare.net/aparnachaudhary/docker-tipsforjavadevelopers)
 - [Eclipse MicroProfile: A new standard for building Microservices? - Edwin Derks](./content/eclipse-micro-profile.zip)
-- [Unidirectional Data Flow Architecture: From Swift to JS and Back Again - Stefan van den Oord](https://github.com/svdo/UnidirectionalFlowTalk.)
+- [Unidirectional Data Flow Architecture: From Swift to JS and Back Again - Stefan van den Oord](https://github.com/svdo/UnidirectionalFlowTalk/blob/master/Slides.pdf)
 - [Over-engineering: The hidden monster - Mete Bulutay](./content/Over-Engineering_NextBuild2018.pdf)
 - [Creating a brain to outsmart a baby - Marianne Schimmel](https://www.slideshare.net/MarianneKrause/creating-a-brain-to-outsmart-a-baby)
 - [Property based testing in Elixir - Luc Tielen](./content/PBT_elixir_final.key)


### PR DESCRIPTION
The previous link resulted in a 404. Update the link to point to the actual slides